### PR TITLE
Fix attempt to call a nil value (global ‘ValidPedModel’)

### DIFF
--- a/server/server.lua
+++ b/server/server.lua
@@ -90,7 +90,7 @@ end
 
 local validModel = false
 
-local function ValidPedModel(pedModel)
+function ValidPedModel(pedModel)
     if pedModel and type(pedModel) == 'string' then
         for i = 1, #Peds.VanillaList do
             local validPed = Peds.VanillaList[i]


### PR DESCRIPTION
Fix server.lua:53 attempt to call a nil value (global ‘ValidPedModel’) 

thx : ROCKY_southpaw